### PR TITLE
SQLAbst to allow usage of Transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/andreburgaud/crypt2go v1.1.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-nulltype v0.0.0-20200221160555-75ae8a76f2e9
+	github.com/nurcahyaari/sqlabst v0.0.0-20220902160139-0f2eb23feed8
 	github.com/xeodou/go-sqlcipher v0.0.0-20200727080346-d681773ef093
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/tools v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,10 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andreburgaud/crypt2go v1.1.0 h1:eitZxTPY1krUsxinsng3Qvt/Ud7q/aQmmYRh8p4hyPw=
 github.com/andreburgaud/crypt2go v1.1.0/go.mod h1:4qhZPzarj1dCIRmCkpdgCklwp+hBq9yEt0zPe9Ayuhc=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnXyBns=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -28,12 +30,16 @@ github.com/mattn/go-nulltype v0.0.0-20200221160555-75ae8a76f2e9/go.mod h1:XIOm21
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.14 h1:qZgc/Rwetq+MtyE18WhzjokPD93dNqLGNT3QJuLvBGw=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/nurcahyaari/sqlabst v0.0.0-20220902160139-0f2eb23feed8 h1:Qb/QOQxMOMCIOjLqt/zy+fhCw7C+uuvyVsgx29EbKQk=
+github.com/nurcahyaari/sqlabst v0.0.0-20220902160139-0f2eb23feed8/go.mod h1:khiKdsgBLVHEnaeXXy26A0VctERUkAVanBUzqDLDlXA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/xeodou/go-sqlcipher v0.0.0-20200727080346-d681773ef093 h1:B6yl+jqs5t4C27I16+t1gn28lPlZgjLGxZehsK+jFfA=
 github.com/xeodou/go-sqlcipher v0.0.0-20200727080346-d681773ef093/go.mod h1:aZ06jyRpOCqbZdcLUsn8agGfXzlKkHbQp/CjwRKwxSQ=
 github.com/xo/xo v0.0.0-20220429050349-42b11c7999bc h1:r3A1rlcqjaTfbxsfRZQtVtVDfGuJzLRn3WTF8TMkW0g=
@@ -57,5 +63,6 @@ golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f h1:GGU+dLjvlC3qDwqYgL6Ug
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 mvdan.cc/gofumpt v0.3.1 h1:avhhrOmv0IuvQVK7fvwV91oFSGAk5/6Po8GXTzICeu8=
 mvdan.cc/gofumpt v0.3.1/go.mod h1:w3ymliuxvzVx8DAutBnVyDqYb1Niy/yCJt/lk821YCE=

--- a/rekordbox/client.go
+++ b/rekordbox/client.go
@@ -3,10 +3,11 @@ package rekordbox
 import (
 	"github.com/dvcrn/go-rekordbox/internal/supbox"
 	"github.com/jmoiron/sqlx"
+	"github.com/nurcahyaari/sqlabst"
 )
 
 type Client struct {
-	db *sqlx.DB
+	db *sqlabst.SqlAbst
 }
 
 func NewClient(optionsFilePath string) (*Client, error) {
@@ -27,13 +28,17 @@ func NewClient(optionsFilePath string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{db: db}, nil
+	return &Client{db: sqlabst.NewSqlAbst(db)}, nil
 }
 
 func (c *Client) Close() {
 	c.db.Close()
 }
 
-func (c *Client) GetDB() *sqlx.DB {
+func (c *Client) GetSqlAbst() *sqlabst.SqlAbst {
 	return c.db
+}
+
+func (c *Client) GetDB() *sqlx.DB {
+	return c.db.GetDB()
 }


### PR DESCRIPTION
As I wanted to build a feature that allows for preview of a modification I needed Transactions to work. I feel like I added the possibility for them in the most minimal invasive way :-)

Simple get the SQLAbst and call Beginx(context.Context) to start one. After a rollback or commit the library will get back to using the db.

Of course this might not be 100% nice in a very concurrent setup but then it makes more sense to just use several clients probably...